### PR TITLE
Update peerDependencies to support Svelte 5.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
 		"!dist/**/*.spec.*"
 	],
 	"peerDependencies": {
-		"svelte": "^4.0.0"
+		"svelte": ">=4.0.0 <6.0.0"
 	},
 	"devDependencies": {
 		"@sveltejs/adapter-auto": "^3.0.0",


### PR DESCRIPTION
### Fixing peer dependency
Just changed the package.json peerDependencies to support svelte 5